### PR TITLE
Removed README instruction to install PhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ To install this application on your computer, you can simply use NPM to install 
 npm install -g makemeasandwich
 ```
 
-Next you will need to <a href="http://phantomjs.org/download.html">Install Phantom.js</a>.
-
-
 Usage
 ---------------------------
 To run this command, simply type it in your terminal.


### PR DESCRIPTION
It's no longer necessary to install manually since it was added
as a dependency to jquery.go.js

Thanks :)

You'll need to `npm publish` the new version of jquery.go.js though so that npm has the updated dependencies.
