### PR TITLE
Fix Linux/Mac path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This order json file looks like the following...
 }
 ```
 
-If you'd like to save the order json for repeated use, simply add it to either `X:\mmas\config.json` in Windows (where X is your primary drive letter) or `\etc\mmas\config.json` in Linux/Mac. However, do note that using `-o order.json` will override the saved config.json.
+If you'd like to save the order json for repeated use, simply add it to either `X:\mmas\config.json` in Windows (where X is your primary drive letter) or `/etc/mmas/config.json` in Linux/Mac. However, do note that using `-o order.json` will override the saved config.json.
 
 Using the Makefile
 ------------------------------


### PR DESCRIPTION
Linux/Mac uses forward-slashes in path.
